### PR TITLE
show test durations

### DIFF
--- a/enochecker_test/main.py
+++ b/enochecker_test/main.py
@@ -42,6 +42,7 @@ def run_tests(host, port, service_address):
                 f"--flag-variants={info.flag_variants}",
                 f"--noise-variants={info.noise_variants}",
                 f"--havoc-variants={info.havoc_variants}",
+                "--durations=0",
                 os.path.join(os.path.dirname(__file__), "tests.py"),
             ]
         )


### PR DESCRIPTION
Looks like this:

```
============================================================================================================================= slowest durations =============================================================================================================================
4.24s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getflag[0]
4.18s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getflag_multiplied[1-1]
4.18s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getnoise[0]
4.15s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getnoise_multiplied[1-1]
2.24s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putflag[0]
2.13s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc[2]
2.13s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc_multiplied[5-3]
2.13s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putflag_multiplied[1-1]
2.11s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putnoise_multiplied[1-1]
2.10s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putnoise[0]
2.06s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getflag_invalid_variant[1]
2.06s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc_multiplied[4-3]
2.06s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc[1]
2.05s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putflag_invalid_variant[1]
2.05s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc_invalid_variant[3]
2.05s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc[0]
2.03s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_getnoise_invalid_variant[1]
2.03s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_havoc_multiplied[3-3]
2.03s call     AppData/Local/Packages/PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0/LocalCache/local-packages/Python39/site-packages/enochecker_test/tests.py::test_putnoise_invalid_variant[1]

(38 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================================================================ 19 passed in 48.10s ============================================================================================================================
```