### PR TITLE
add option to skip non standard flags

### DIFF
--- a/enochecker_test/conftest.py
+++ b/enochecker_test/conftest.py
@@ -2,6 +2,7 @@ def pytest_addoption(parser):
     parser.addoption("--checker-address", action="store", type=str)
     parser.addoption("--checker-port", action="store", type=int)
     parser.addoption("--service-address", action="store", type=str)
+    parser.addoption("--skip-non-eno-flags", action="store_true")
     parser.addoption("--flag-variants", action="store", type=int)
     parser.addoption("--noise-variants", action="store", type=int)
     parser.addoption("--havoc-variants", action="store", type=int)

--- a/enochecker_test/main.py
+++ b/enochecker_test/main.py
@@ -11,7 +11,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
-def run_tests(host, port, service_address, test_expr):
+def run_tests(host, port, service_address, test_expr, skip_non_eno_flags: bool):
     s = requests.Session()
     retry_strategy = Retry(
         total=5,
@@ -44,7 +44,7 @@ def run_tests(host, port, service_address, test_expr):
         f"--exploit-variants={info.exploit_variants}",
         "--durations=0",
         "-v",
-    ]
+    ] + (["--skip-non-eno-flags"] if skip_non_eno_flags else [])
 
     if test_expr:
         test_args.append("-k")
@@ -92,6 +92,11 @@ service's docker container as obtained by e.g:
         default=os.environ.get("ENOCHECKER_TEST_SERVICE_ADDRESS"),
     )
     parser.add_argument(
+        "--skip-non-eno-flags",
+        action="store_true",
+        help="Skips all test that do not use a ENO[A-Za-z0-9+/=]{48} flag. SHOULD ONLY BE USED AS AN EXCEPTION!!",
+    )
+    parser.add_argument(
         "testexpr",
         help="Specify the tests that should be run in the syntax expected by pytests -k flag, e.g. 'test_getflag' or 'not exploit'. If no expr is specified, all tests will be run.",
         nargs="?",
@@ -117,5 +122,9 @@ service's docker container as obtained by e.g:
 
     logging.basicConfig(level=logging.INFO)
     run_tests(
-        args.checker_address, args.checker_port, args.service_address, args.testexpr
+        args.checker_address,
+        args.checker_port,
+        args.service_address,
+        args.testexpr,
+        args.skip_non_eno_flags,
     )

--- a/enochecker_test/tests.py
+++ b/enochecker_test/tests.py
@@ -42,6 +42,16 @@ def checker_url(checker_address, checker_port):
     return f"http://{checker_address}:{checker_port}"
 
 
+posible_encodings = ["ascii", "utf8"]
+
+
+@pytest.fixture(params=posible_encodings)
+def encoding(request):
+    if request.config.getoption("--skip-non-eno-flags") and request.param != "ascii":
+        pytest.skip("skipped by --skip-non-eno-flags")
+    return request.param
+
+
 def pytest_generate_tests(metafunc):
     flag_variants: int = metafunc.config.getoption("--flag-variants")
     noise_variants: int = metafunc.config.getoption("--noise-variants")
@@ -79,9 +89,6 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("exploit_id", range(exploit_variants))
     if "exploit_variants" in metafunc.fixturenames:
         metafunc.parametrize("exploit_variants", [exploit_variants])
-
-    if "encoding" in metafunc.fixturenames:
-        metafunc.parametrize("encoding", ["ascii", "utf8"])
 
 
 def generate_dummyflag(encoding: str) -> str:


### PR DESCRIPTION
my service requires the default `ENO[A-Za-z0-9+\/=]{48}` flag structure, so my CI/CD fails when `enochecker_test`.
To remedy this, I want to add a option to skip (not remove) those tests.
Bike shedding is welcome.