### PR TITLE
add expressive exception in _do_exploit_run

### DIFF
--- a/enochecker_test/tests.py
+++ b/enochecker_test/tests.py
@@ -634,7 +634,11 @@ def _do_exploit_run(
             checker_url,
         )
         print(found_flag)
-        return found_flag == flag, None
+        if found_flag == flag:
+            return True, None
+
+        return False, Exception(f"Found flag is incorrect. Expected: {flag}. Found: {found_flag}")
+
     except Exception as e:
         return False, e
 


### PR DESCRIPTION
Return of an exception together with the return value `False` to facilitate troubleshooting by means of the meaningful exception. Otherwise [#L653](https://github.com/enowars/enochecker_test/blob/main/enochecker_test/tests.py#L653) would just raise `Exception[none]` for an incorrect flag.  