### PR TITLE
add option to skip all tests with non-ascii flags

### DIFF
--- a/src/enochecker_test/conftest.py
+++ b/src/enochecker_test/conftest.py
@@ -23,6 +23,7 @@ def pytest_addoption(parser):
     parser.addoption("--multiplier", action="store", type=int)
     parser.addoption("--seed", action="store", type=int)
     parser.addoption("--stress", action="store", type=bool)
+    parser.addoption("--no-utf8-flags", action="store_true", default=False)
 
 
 def pytest_configure(config):

--- a/src/enochecker_test/conftest.py
+++ b/src/enochecker_test/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
     parser.addoption("--multiplier", action="store", type=int)
     parser.addoption("--seed", action="store", type=int)
     parser.addoption("--stress", action="store", type=bool)
-    parser.addoption("--no-utf8-flags", action="store_true", default=False)
+    parser.addoption("--flag-types", action="store", default="ascii,utf8")
 
 
 def pytest_configure(config):

--- a/src/enochecker_test/main.py
+++ b/src/enochecker_test/main.py
@@ -136,6 +136,7 @@ service's docker container as obtained by e.g:
         "--no-utf8-flags",
         help="Skip all tests that use non-ASCII (UTF-8) flags",
         action="store_true",
+        default=os.environ.get("ENOCHECKER_NO_UTF8_FLAGS", "").lower() in ("1", "true", "yes", "on")
     )
     parser.add_argument(
         "testexpr",

--- a/src/enochecker_test/main.py
+++ b/src/enochecker_test/main.py
@@ -16,7 +16,7 @@ def run_tests(
     multiplier: int,
     seed: int,
     stress: bool,
-    no_utf8_flags: bool = False,
+    flag_types: str = "ascii,utf8",
 ):
     transport = httpx.HTTPTransport(retries=10)
     with httpx.Client(transport=transport) as client:
@@ -53,8 +53,7 @@ def run_tests(
     ]
     if stress:
         test_args.append("--stress")
-    if no_utf8_flags:
-        test_args.append("--no-utf8-flags")
+    test_args.append(f"--flag-types={flag_types}")
 
     if test_expr:
         test_args.append("-k")
@@ -133,10 +132,9 @@ service's docker container as obtained by e.g:
         action="store_true",
     )
     parser.add_argument(
-        "--no-utf8-flags",
-        help="Skip all tests that use non-ASCII (UTF-8) flags",
-        action="store_true",
-        default=os.environ.get("ENOCHECKER_NO_UTF8_FLAGS", "").lower() in ("1", "true", "yes", "on")
+        "--flag-types",
+        help="Comma-separated list of flag encodings to test (default: ascii,utf8)",
+        default=os.environ.get("ENOCHECKER_FLAG_TYPES", "ascii,utf8"),
     )
     parser.add_argument(
         "testexpr",
@@ -179,5 +177,5 @@ service's docker container as obtained by e.g:
         args.multiplier,
         args.seed,
         args.stress,
-        args.no_utf8_flags,
+        args.flag_types,
     )

--- a/src/enochecker_test/main.py
+++ b/src/enochecker_test/main.py
@@ -16,6 +16,7 @@ def run_tests(
     multiplier: int,
     seed: int,
     stress: bool,
+    no_utf8_flags: bool = False,
 ):
     transport = httpx.HTTPTransport(retries=10)
     with httpx.Client(transport=transport) as client:
@@ -52,6 +53,8 @@ def run_tests(
     ]
     if stress:
         test_args.append("--stress")
+    if no_utf8_flags:
+        test_args.append("--no-utf8-flags")
 
     if test_expr:
         test_args.append("-k")
@@ -130,6 +133,11 @@ service's docker container as obtained by e.g:
         action="store_true",
     )
     parser.add_argument(
+        "--no-utf8-flags",
+        help="Skip all tests that use non-ASCII (UTF-8) flags",
+        action="store_true",
+    )
+    parser.add_argument(
         "testexpr",
         help="Specify the tests that should be run in the syntax expected by pytests -k flag, e.g. 'test_getflag' or 'not exploit'. If no expr is specified, all tests will be run.",
         nargs="?",
@@ -170,4 +178,5 @@ service's docker container as obtained by e.g:
         args.multiplier,
         args.seed,
         args.stress,
+        args.no_utf8_flags,
     )

--- a/src/enochecker_test/tests.py
+++ b/src/enochecker_test/tests.py
@@ -114,8 +114,8 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("test_id", range(test_variants))
 
     if "encoding" in metafunc.fixturenames:
-        skip_utf8 = metafunc.config.getoption("--no-utf8-flags")
-        encodings = ["ascii"] if skip_utf8 else ["ascii", "utf8"]
+        flag_types = metafunc.config.getoption("--flag-types")
+        encodings = [t.strip() for t in flag_types.split(",") if t.strip()]
         metafunc.parametrize("encoding", encodings)
 
     if "stress_multiplier" in metafunc.fixturenames:

--- a/src/enochecker_test/tests.py
+++ b/src/enochecker_test/tests.py
@@ -114,7 +114,9 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("test_id", range(test_variants))
 
     if "encoding" in metafunc.fixturenames:
-        metafunc.parametrize("encoding", ["ascii", "utf8"])
+        skip_utf8 = metafunc.config.getoption("--no-utf8-flags")
+        encodings = ["ascii"] if skip_utf8 else ["ascii", "utf8"]
+        metafunc.parametrize("encoding", encodings)
 
     if "stress_multiplier" in metafunc.fixturenames:
         metafunc.parametrize("stress_multiplier", [32, 128, 512])


### PR DESCRIPTION
required for services that do not support utf8